### PR TITLE
Fix third test

### DIFF
--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -36,12 +36,12 @@ pub fn derive(input: TokenStream) -> TokenStream {
             let name_ident = f.ident.as_ref().expect("only named fields allowed.");
             let name_str = name_ident.to_string();
             let format_string = get_format_string_for_field(&f);
-            println!("{:#?}", format_string);
+            //println!("{:#?}", format_string);
 
             if let Some(fs) = format_string {
-                println!("{}", fs);
+                //println!("{}", fs);
                 quote! {
-                    .field(#name_str, &format!("{}", format_args!(#fs, &self.#name_ident)))
+                    .field(#name_str, &format_args!(#fs, self.#name_ident))
                 }
             } else {
                 quote! {
@@ -60,8 +60,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
                     #(
                         #fields_format_vec
                     )*
-                    .finish();
-                Ok(())
+                    .finish()
             }
         }
     };


### PR DESCRIPTION
Hi, you had a `format!` that wasn't necessary and it made the compiler believe the field was a `String` so it formatted it like a `String`.
You also had an unused `Result` in `Debug::fmt`, `finish` returns a `Result<(), fmt::Error>`.